### PR TITLE
Add /v1/users/settings/password/change

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -55,10 +55,8 @@ exports.changePassword = async function(params) {
   if (!user) {
     return apiError('Not registered');
   }
-  console.log(user._id);
 
   const hash = calcPasswordHash(params.currentPassword, user.passwordSalt);
-
   if (hash !== user.passwordSha256) {
     return apiError('Forbidden');
   } else {
@@ -71,7 +69,6 @@ exports.changePassword = async function(params) {
     });
 
     user = await User.findById(user.id);
-    console.log(user);
 
     return apiSuccess();
   }

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -51,7 +51,7 @@ exports.changePassword = async function(params) {
   if (!userId) {
     return apiError('Not logged in');
   }
-  let user = await User.findById(userId);
+  const user = await User.findById(userId);
   if (!user) {
     return apiError('Not registered');
   }
@@ -67,8 +67,6 @@ exports.changePassword = async function(params) {
         passwordSalt: newSalt,
         passwordSha256: newHash},
     });
-
-    user = await User.findById(user.id);
 
     return apiSuccess();
   }

--- a/routes/v1/usersRouter.js
+++ b/routes/v1/usersRouter.js
@@ -13,4 +13,24 @@ router.post('/register', async (req, res) => {
   }));
 });
 
+router.post('/login', async (req, res) => {
+  const email = String(req.body.email);
+  const password = String(req.body.password);
+
+  res.json(await userController.login({
+    email, password,
+  }));
+});
+
+
+router.post('/settings/password/change', async (req, res) => {
+  const currentPassword = String(req.body.currentPassword);
+  const newPassword = String(req.body.newPassword);
+  const token = String(req.body.token);
+
+  res.json(await userController.changePassword({
+    currentPassword, newPassword, token,
+  }));
+});
+
 module.exports = router;


### PR DESCRIPTION
Add /v1/users/settings/password/change to allow users to change password with token, currentPassword and newPassword

If user is not logged in yet, reject request. If hash calculated from currentPassword and User passwordSalt doesn't match User's stored passwordHash, reject request. Otherwise, generate new salt and calculate new hash and update User database. 

#7 